### PR TITLE
Only run `deploy` job if the trigger was a push to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,6 +68,7 @@ jobs:
         uses: amoeba/standardrb-action@v2
 
   deploy:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: [build-and-test, lint]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This fixes  an issue (#3) where opening a PR, even one that's not yet complete, could trigger a deploy