### PR TITLE
Add flash messages

### DIFF
--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+  }
+
+  close() {
+    if (this.element) {
+      this.element.remove()
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,5 +3,8 @@
 
 import { application } from "./application"
 
-import HelloController from "./hello_controller"
+import FlashController from "./flash_controller.js"
+application.register("flash", FlashController)
+
+import HelloController from "./hello_controller.js"
 application.register("hello", HelloController)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,4 +8,14 @@
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
   %body
+    .rounded-t-lg.overflow-hidden.border-t.border-l.border-r.border-gray-400.p-4
+      - flash.each do |type, msg|
+        - dialog_classes = type == "alert" ? "bg-red-100 border-red-400 text-red-700" : "bg-blue-100 border-blue-400 text-blue-700"
+        - dismiss_classes = type == "alert" ? "text-red-500" : "text-blue-500"
+        .border.px-4.py-3.mb-2.rounded.relative{class: dialog_classes, role: "alert"}
+          %span.block.sm:inline= msg
+          %span.absolute.top-0.bottom-0.right-0.px-4.py-3
+            %svg.fill-current.h-6.w-6{class: dismiss_classes, role: "button", viewbox: "0 0 20 20", xmlns: "http://www.w3.org/2000/svg"}
+              %title Close
+              %path{:d => "M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"}
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,9 +12,9 @@
       - flash.each do |type, msg|
         - dialog_classes = type == "alert" ? "bg-red-100 border-red-400 text-red-700" : "bg-blue-100 border-blue-400 text-blue-700"
         - dismiss_classes = type == "alert" ? "text-red-500" : "text-blue-500"
-        .border.px-4.py-3.mb-2.rounded.relative{class: dialog_classes, role: "alert"}
+        .border.px-4.py-3.mb-2.rounded.relative{class: dialog_classes, data: {controller: "flash"}, role: "alert"}
           %span.block.sm:inline= msg
-          %span.absolute.top-0.bottom-0.right-0.px-4.py-3
+          %span.absolute.top-0.bottom-0.right-0.px-4.py-3{data: {action: "click->flash#close"}}
             %svg.fill-current.h-6.w-6{class: dismiss_classes, role: "button", viewbox: "0 0 20 20", xmlns: "http://www.w3.org/2000/svg"}
               %title Close
               %path{:d => "M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,7 +8,7 @@
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
   %body
-    .rounded-t-lg.overflow-hidden.border-t.border-l.border-r.border-gray-400.p-4
+    .container.mx-auto.my-8.px-4
       - flash.each do |type, msg|
         - dialog_classes = type == "alert" ? "bg-red-100 border-red-400 text-red-700" : "bg-blue-100 border-blue-400 text-blue-700"
         - dismiss_classes = type == "alert" ? "text-red-500" : "text-blue-500"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,7 +9,7 @@
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
   %body
     .container.mx-auto.my-8.px-4
-      - flash.each do |type, msg|
+      - flash.sort_by(&:first).each do |type, msg|
         - dialog_classes = type == "alert" ? "bg-red-100 border-red-400 text-red-700" : "bg-blue-100 border-blue-400 text-blue-700"
         - dismiss_classes = type == "alert" ? "text-red-500" : "text-blue-500"
         .border.px-4.py-3.mb-2.rounded.relative{class: dialog_classes, data: {controller: "flash"}, role: "alert"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,7 +14,7 @@
         - dismiss_classes = type == "alert" ? "text-red-500" : "text-blue-500"
         .border.px-4.py-3.mb-2.rounded.relative{class: dialog_classes, data: {controller: "flash"}, role: "alert"}
           %span.block.sm:inline= msg
-          %span.absolute.top-0.bottom-0.right-0.px-4.py-3{data: {action: "click->flash#close"}}
+          %span.absolute.top-0.bottom-0.right-0.px-4.py-3.hover:scale-120{data: {action: "click->flash#close"}}
             %svg.fill-current.h-6.w-6{class: dismiss_classes, role: "button", viewbox: "0 0 20 20", xmlns: "http://www.w3.org/2000/svg"}
               %title Close
               %path{:d => "M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"}


### PR DESCRIPTION
This adds simple flash messages that can be dismissed once they have been read.

At this stage it only supports [the two default types supplied by Rails](https://api.rubyonrails.org/classes/ActionDispatch/Flash.html), `alert` and `notice`.

Messages with an `alert` type are styled in red, all other types (only `notice` at the moment) are styled in blue and `alert`s are listed first (sorted alphabetically by type).

<img width="755" alt="image" src="https://user-images.githubusercontent.com/19525237/139515988-706734cf-c7fe-434d-b051-1043fb3193ed.png">

Styling comes from Tailwind CSS [v1 documentation](https://v1.tailwindcss.com/components/alerts).
